### PR TITLE
feat/refactor(duty): enhances shift management with persistent interactions

### DIFF
--- a/Source/Commands/Utility/ServerData/Subcmds/Manage.ts
+++ b/Source/Commands/Utility/ServerData/Subcmds/Manage.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/cognitive-complexity */
 import {
   SlashCommandSubcommandBuilder,
   StringSelectMenuOptionBuilder,

--- a/Source/Events/InteractionCreate/ComponentTimeoutHandler.ts
+++ b/Source/Events/InteractionCreate/ComponentTimeoutHandler.ts
@@ -2,7 +2,11 @@ import AppLogger from "@Utilities/Classes/AppLogger.js";
 import { IsValidDiscordId } from "@Utilities/Other/Validators.js";
 import { differenceInMilliseconds } from "date-fns";
 import { InfoEmbed, UnauthorizedEmbed } from "@Utilities/Classes/ExtraEmbeds.js";
-import { UserActivityNoticeMgmtCustomIdRegex } from "@Resources/RegularExpressions.js";
+import {
+  DutyManagementBtnCustomIdRegex,
+  UserActivityNoticeMgmtCustomIdRegex,
+} from "@Resources/RegularExpressions.js";
+
 import {
   MessageFlags,
   ComponentType,
@@ -11,7 +15,10 @@ import {
   createComponentBuilder,
 } from "discord.js";
 
-const UnauthorizedUsageIgnoredCompsWithCustomIds: RegExp[] = [UserActivityNoticeMgmtCustomIdRegex];
+const UnauthorizedUsageIgnoredCompsWithCustomIds: RegExp[] = [
+  UserActivityNoticeMgmtCustomIdRegex,
+  DutyManagementBtnCustomIdRegex,
+];
 
 /**
  * For handling & responding to any component that have been abandoned activated.

--- a/Source/Events/InteractionCreate/ShiftManagementHandler.ts
+++ b/Source/Events/InteractionCreate/ShiftManagementHandler.ts
@@ -1,0 +1,643 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+// Dependencies:
+// -------------
+
+import {
+  inlineCode,
+  EmbedBuilder,
+  BaseInteraction,
+  ButtonInteraction,
+  time as FormatTime,
+} from "discord.js";
+
+import {
+  ShiftMgmtActions,
+  RecentShiftAction,
+  GetShiftManagementButtons,
+  CheckShiftTypeRestrictions,
+} from "@Cmds/Miscellaneous/Duty/Subcmds/Manage.js";
+
+import { Shifts } from "@Typings/Utilities/Database.js";
+import { GetErrorId } from "@Utilities/Strings/Random.js";
+import { secondsInDay } from "date-fns/constants";
+import { ErrorMessages } from "@Resources/AppMessages.js";
+import { Embeds, Emojis } from "@Config/Shared.js";
+import { differenceInSeconds } from "date-fns";
+import { ErrorEmbed, UnauthorizedEmbed } from "@Utilities/Classes/ExtraEmbeds.js";
+import { DutyManagementBtnCustomIdRegex } from "@Resources/RegularExpressions.js";
+import { IsValidDiscordId, IsValidShiftTypeName } from "@Utilities/Other/Validators.js";
+
+import HandleRoleAssignment from "@Utilities/Other/HandleShiftRoleAssignment.js";
+import GetMainShiftsData from "@Utilities/Database/GetShiftsData.js";
+import ShiftActionLogger from "@Utilities/Classes/ShiftActionLogger.js";
+import GetGuildSettings from "@Utilities/Database/GetGuildSettings.js";
+import GetActiveShift from "@Utilities/Database/GetShiftActive.js";
+import ShiftModel from "@Models/Shift.js";
+import AppLogger from "@Utilities/Classes/AppLogger.js";
+import DHumanize from "humanize-duration";
+import AppError from "@Utilities/Classes/AppError.js";
+import Dedent from "dedent";
+
+type ShiftDocument = Shifts.HydratedShiftDocument;
+const FileLabel = "Events:InteractionCreate:ShiftManagementHandler";
+const HumanizeDuration = DHumanize.humanizer({
+  conjunction: " and ",
+  largest: 3,
+  round: true,
+});
+
+// ---------------------------------------------------------------------------------------
+// Initial Handling:
+// -----------------
+/**
+ * Handles all User Activity Notice management button interactions.
+ * @param _ - Discord client instance (unused parameter).
+ * @param Interaction - The button interaction to process.
+ * @returns
+ */
+export default async function ShiftManagementHandlerWrapper(
+  _: DiscordClient,
+  Interaction: BaseInteraction
+) {
+  if (
+    !Interaction.isButton() ||
+    !Interaction.inCachedGuild() ||
+    !DutyManagementBtnCustomIdRegex.test(Interaction.customId)
+  ) {
+    return;
+  }
+
+  try {
+    const ValidationResult = await HandleUnauthorizedShiftManagement(Interaction);
+    if (ValidationResult.handled || !ValidationResult.target_shift_type) return;
+
+    await ShiftManagementHandler(Interaction, ValidationResult.target_shift_type);
+    const ButtonResponded = Interaction.deferred || Interaction.replied;
+    if (!ButtonResponded) {
+      await Interaction.deferUpdate().catch(() => null);
+    }
+  } catch (Err: any) {
+    if (Err instanceof AppError && Err.is_showable) {
+      return new ErrorEmbed().useErrClass(Err).replyToInteract(Interaction, true);
+    }
+
+    const ErrorId = GetErrorId();
+    AppLogger.error({
+      message: "Failed to handle shift management button interaction;",
+      error_id: ErrorId,
+      label: FileLabel,
+      stack: Err.stack,
+    });
+
+    return new ErrorEmbed()
+      .useErrTemplate("AppError")
+      .setErrorId(ErrorId)
+      .replyToInteract(Interaction, true);
+  }
+}
+
+// ---------------------------------------------------------------------------------------
+// Action Handling:
+// ----------------
+async function ShiftManagementHandler(
+  Interaction: ButtonInteraction<"cached">,
+  TargetShiftType: string
+) {
+  const SplatDetails = Interaction.customId.split(":");
+  const ShiftAction = SplatDetails[0] as ShiftMgmtActions;
+  const TargetShiftId = SplatDetails[3];
+  const PromptMessageId = Interaction.message.id;
+
+  const TargetShift = await ShiftModel.findById(TargetShiftId).exec();
+  const ActiveShift =
+    TargetShift?.end_timestamp === null
+      ? TargetShift
+      : await GetActiveShift({
+          UserOnly: true,
+          Interaction,
+        });
+
+  if (await HandleInvalidShiftAction(Interaction, ShiftAction, TargetShift)) return;
+  const CurrentShiftType = ActiveShift?.type ?? TargetShiftType;
+
+  switch (ShiftAction) {
+    case ShiftMgmtActions.ShiftOn:
+      return HandleShiftOnAction(Interaction, CurrentShiftType, PromptMessageId);
+    case ShiftMgmtActions.ShiftOff:
+      return HandleShiftOffAction(Interaction, ActiveShift!, PromptMessageId);
+    case ShiftMgmtActions.ShiftBreakToggle:
+      return HandleShiftBreakToggleAction(Interaction, ActiveShift!, PromptMessageId);
+    default:
+      throw new Error(`Unhandled ShiftAction: ${ShiftAction}`);
+  }
+}
+
+async function HandleShiftOnAction(
+  Interaction: ButtonInteraction<"cached">,
+  TShiftType: string,
+  PromptMsgId: string
+) {
+  if (!Interaction.customId.startsWith(ShiftMgmtActions.ShiftOn)) return;
+  try {
+    const StartedShift = await ShiftModel.startNewShift({
+      type: TShiftType,
+      user: Interaction.user.id,
+      guild: Interaction.guildId,
+      start_timestamp: Interaction.createdAt,
+    });
+
+    await Promise.all([
+      ShiftActionLogger.LogShiftStart(StartedShift, Interaction),
+      HandleRoleAssignment("on-duty", Interaction.client, Interaction.guild, Interaction.user.id),
+      UpdateManagementPrompt(
+        Interaction,
+        TShiftType,
+        PromptMsgId,
+        StartedShift,
+        RecentShiftAction.Start
+      ),
+    ]);
+  } catch (Err: any) {
+    const ErrorId = GetErrorId();
+    if (Err instanceof AppError && Err.is_showable) {
+      if (Err.title === ErrorMessages.ShiftAlreadyActive.Title) {
+        const ActiveShift = await GetActiveShift({
+          UserOnly: true,
+          Interaction,
+        });
+
+        if (ActiveShift?.type === TShiftType) {
+          await Interaction.deferUpdate().catch(() => null);
+          return Promise.allSettled([
+            new ErrorEmbed()
+              .useErrTemplate("DSMStateChangedExternally")
+              .replyToInteract(Interaction, true, true, "followUp"),
+            UpdateManagementPrompt(
+              Interaction,
+              TShiftType,
+              PromptMsgId,
+              ActiveShift,
+              RecentShiftAction.Start
+            ),
+          ]);
+        } else {
+          return new ErrorEmbed()
+            .useErrClass(Err)
+            .replyToInteract(Interaction, true, true, "reply");
+        }
+      }
+
+      new ErrorEmbed()
+        .useErrClass(Err)
+        .setErrorId(ErrorId)
+        .replyToInteract(Interaction, true, true, "reply");
+    }
+
+    AppLogger.error({
+      message: "An error occurred while creating a new shift record;",
+      label: FileLabel,
+      user_id: Interaction.user.id,
+      guild_id: Interaction.guildId,
+      error_id: ErrorId,
+      stack: Err.stack,
+    });
+  }
+}
+
+async function HandleShiftBreakToggleAction(
+  Interaction: ButtonInteraction<"cached">,
+  ActiveShift: ShiftDocument,
+  PromptMsgId: string
+) {
+  if (!Interaction.customId.startsWith(ShiftMgmtActions.ShiftBreakToggle)) return;
+  const BreakActionType = ActiveShift.hasBreakActive() ? "End" : "Start";
+  let UpdatedShift: ShiftDocument | null = null;
+
+  try {
+    UpdatedShift = (await ActiveShift[`break${BreakActionType}`](
+      Interaction.createdTimestamp
+    )) as ShiftDocument;
+
+    return Promise.all([
+      ShiftActionLogger[`LogShiftBreak${BreakActionType}`](UpdatedShift, Interaction),
+      HandleRoleAssignment(
+        BreakActionType === "End" ? "on-duty" : "on-break",
+        Interaction.client,
+        Interaction.guild,
+        Interaction.user.id
+      ),
+      UpdateManagementPrompt(
+        Interaction,
+        UpdatedShift.type,
+        PromptMsgId,
+        UpdatedShift,
+        RecentShiftAction[`Break${BreakActionType}`]
+      ),
+    ]);
+  } catch (Err: any) {
+    if (Err instanceof AppError && Err.is_showable) {
+      await Interaction.deferUpdate().catch(() => null);
+      return Promise.allSettled([
+        new ErrorEmbed().useErrClass(Err).replyToInteract(Interaction, true, false, "followUp"),
+        UpdateManagementPrompt(
+          Interaction,
+          ActiveShift.type,
+          PromptMsgId,
+          ActiveShift,
+          RecentShiftAction.BreakStart
+        ),
+      ]);
+    } else {
+      throw Err;
+    }
+  }
+}
+
+async function HandleShiftOffAction(
+  Interaction: ButtonInteraction<"cached">,
+  ActiveShift: ShiftDocument,
+  PromptMsgId: string
+) {
+  if (!Interaction.customId.startsWith(ShiftMgmtActions.ShiftOff)) return;
+  let UpdatedShift: ShiftDocument | null = null;
+
+  try {
+    UpdatedShift = await ActiveShift.end(Interaction.createdTimestamp);
+    return Promise.all([
+      ShiftActionLogger.LogShiftEnd(UpdatedShift, Interaction),
+      HandleRoleAssignment("off-duty", Interaction.client, Interaction.guild, Interaction.user.id),
+      UpdateManagementPrompt(
+        Interaction,
+        UpdatedShift.type,
+        PromptMsgId,
+        UpdatedShift,
+        RecentShiftAction.End
+      ),
+    ]);
+  } catch (Err: any) {
+    if (Err instanceof AppError && Err.is_showable) {
+      const ShiftExists = await ShiftModel.exists({ _id: ActiveShift._id });
+      await Interaction.deferUpdate().catch(() => null);
+      return Promise.allSettled([
+        new ErrorEmbed().useErrClass(Err).replyToInteract(Interaction, true, true, "followUp"),
+        UpdateManagementPrompt(
+          Interaction,
+          ActiveShift.type,
+          PromptMsgId,
+          ActiveShift,
+          ShiftExists ? RecentShiftAction.End : undefined
+        ),
+      ]);
+    } else {
+      throw Err;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------------------
+// Helper Functions:
+// -----------------
+/**
+ * Validates if the user has sufficient permissions to perform shift management actions.
+ * @param Interaction - The button interaction to validate permissions for.
+ * @returns An object indicating whether the interaction was handled and the target shift type.
+ */
+async function HandleUnauthorizedShiftManagement(
+  Interaction: ButtonInteraction<"cached">
+): Promise<{ handled: boolean; target_shift_type: string | null }> {
+  const PredefinedResult: { handled: boolean; target_shift_type: string | null } = {
+    handled: true,
+    target_shift_type: null,
+  };
+
+  // 1. Check if the user who triggered the interaction is the same as the one who initiated it.
+  const OriginUserId = Interaction.customId.split(":")[1] || "";
+  if (IsValidDiscordId(OriginUserId) && Interaction.user.id !== OriginUserId) {
+    return new UnauthorizedEmbed()
+      .useErrTemplate("UnauthorizedInteraction")
+      .replyToInteract(Interaction, true)
+      .then(() => PredefinedResult);
+  }
+
+  // 2. Check if guild document exist before proceeding. We're relying on its settings.
+  const GuildSettings = await GetGuildSettings(Interaction.guildId);
+  if (!GuildSettings) {
+    return new ErrorEmbed()
+      .useErrTemplate("GuildConfigNotFound")
+      .replyToInteract(Interaction, true)
+      .then(() => PredefinedResult);
+  }
+
+  // 3. Extract the target shift type from the initial/continueing interaction and proceed validation.
+  const GShiftTypes = GuildSettings.shift_management.shift_types;
+  const PromptShiftType = ExtractShiftTypeFromPrompt(Interaction);
+  const TargettedShiftAction = Interaction.customId.split(":")[0] as ShiftMgmtActions;
+  const PromptShiftTypeExists =
+    PromptShiftType === "Default" || GShiftTypes.some((Type) => Type.name === PromptShiftType);
+
+  if (!PromptShiftTypeExists && TargettedShiftAction === ShiftMgmtActions.ShiftOn) {
+    return new ErrorEmbed()
+      .useErrTemplate("DSMContinueNoShiftTypeFound")
+      .replyToInteract(Interaction, true)
+      .then(() => PredefinedResult);
+  }
+
+  // 4. Check if the user has the required permissions to perform the action on the target shift type.
+  const IsUsageAllowed = await CheckShiftTypeRestrictions(
+    Interaction,
+    GShiftTypes,
+    PromptShiftType
+  );
+
+  if (!IsUsageAllowed) {
+    return new UnauthorizedEmbed()
+      .useErrTemplate("UnauthorizedShiftTypeUsage")
+      .replyToInteract(Interaction, true)
+      .then(() => PredefinedResult);
+  }
+
+  PredefinedResult.handled = false;
+  PredefinedResult.target_shift_type = PromptShiftType;
+
+  return PredefinedResult;
+}
+
+/**
+ * Invalidates the shift action if some conditions are not met.
+ * @param Interaction - The button interaction to process.
+ * @param ShiftAction - The action to be performed.
+ * @param TargetShift - The target shift document, if any.
+ * @returns
+ */
+async function HandleInvalidShiftAction(
+  Interaction: ButtonInteraction<"cached">,
+  ShiftAction: ShiftMgmtActions,
+  TargetShift?: ShiftDocument | null
+) {
+  const PromptMessageLastEditedTimestamp =
+    Interaction.message.editedTimestamp || Interaction.message.createdTimestamp;
+
+  if (
+    differenceInSeconds(Interaction.createdAt, PromptMessageLastEditedTimestamp) >= secondsInDay
+  ) {
+    await DisablePromptComponents(Interaction, TargetShift?.type);
+    return new ErrorEmbed()
+      .useErrTemplate("DSMContinueExpired")
+      .replyToInteract(Interaction, true, true, "followUp")
+      .then(() => true);
+  }
+
+  if (
+    [ShiftMgmtActions.ShiftOff, ShiftMgmtActions.ShiftBreakToggle].includes(ShiftAction) &&
+    (!TargetShift || TargetShift.end_timestamp !== null)
+  ) {
+    await DisablePromptComponents(Interaction, TargetShift?.type);
+    return new ErrorEmbed()
+      .useErrTemplate("DSMInconsistentShiftActionShiftEnded")
+      .replyToInteract(Interaction, true, true, "followUp")
+      .then(() => true);
+  }
+
+  return false;
+}
+
+/**
+ * Updates the management prompt message with the latest shift information.
+ * @param Interaction - The button interaction to process.
+ * @param TShiftType - The target shift type to be used. First checks if there is a shift type; otherwise uses this shift type.
+ * @param PromptMsgId - The ID of the prompt message to update. Just to be sure.
+ * @param ActiveShift - The active shift document, if any.
+ * @param PreviousAction - The previous action performed on the shift, if any.
+ * @returns
+ */
+async function UpdateManagementPrompt(
+  Interaction: ButtonInteraction<"cached">,
+  TShiftType: string,
+  PromptMsgId: string,
+  ActiveShift?: ShiftDocument | null,
+  PreviousAction?: RecentShiftAction | null
+) {
+  ActiveShift = ActiveShift || (await GetActiveShift({ UserOnly: true, Interaction }));
+  if (ActiveShift?.end_timestamp !== null) ActiveShift = null;
+
+  const ShiftType = ActiveShift?.type ?? TShiftType;
+  const ManagementComponents = GetShiftManagementButtons(Interaction, ShiftType, ActiveShift);
+  const MemberShiftsData = await GetMainShiftsData(
+    {
+      user: Interaction.user.id,
+      guild: Interaction.guildId,
+      type: ActiveShift ? ActiveShift.type : TShiftType,
+    },
+    !!ActiveShift
+  );
+
+  const MgmtEmbedTitle = `Shift Management: \`${ShiftType}\` Type`;
+  const MgmtPromptMainDesc = Dedent(`
+    >>> **Shift Count:** \`${MemberShiftsData.shift_count}\`
+    **Total On-Duty Time:** ${MemberShiftsData.total_onduty}
+    **Average On-Duty Time:** ${MemberShiftsData.avg_onduty}
+  `);
+
+  const PromptEmbed = new EmbedBuilder()
+    .setColor(Embeds.Colors.ShiftNatural)
+    .setTitle(MgmtEmbedTitle);
+
+  if (PreviousAction) {
+    if (PreviousAction === RecentShiftAction.End) {
+      PromptEmbed.setColor(Embeds.Colors.ShiftOff);
+      PromptEmbed.setTitle(PreviousAction);
+      PromptEmbed.setFooter({ text: `Shift Type: ${ShiftType}` });
+
+      const MostRecentFinishedShift = await ShiftModel.findOne({
+        user: Interaction.user.id,
+        guild: Interaction.guildId,
+        end_timestamp: { $ne: null },
+      }).sort({ end_timestamp: -1 });
+
+      if (MostRecentFinishedShift) {
+        const BreakTimeText =
+          MostRecentFinishedShift.durations.on_break > 500
+            ? `**Break Time:** ${MostRecentFinishedShift.on_break_time}`
+            : "";
+
+        PromptEmbed.addFields(
+          {
+            inline: true,
+            name: "Shift Overview",
+            value: Dedent(`
+              >>> **Status:** (${Emojis.Offline}) Off-Duty
+              **Shift Time:** ${MostRecentFinishedShift.on_duty_time}
+              ${BreakTimeText}
+            `),
+          },
+          {
+            inline: true,
+            name: "Shift Activity",
+            value: Dedent(`
+              >>> **Arrests Made:** \`${MostRecentFinishedShift.events.arrests}\`
+              **Citations Issued:** \`${MostRecentFinishedShift.events.citations}\`
+              **Incidents Reported:** \`${MostRecentFinishedShift.events.incidents}\`
+            `),
+          },
+          {
+            inline: false,
+            name: "Statistics Summary",
+            value: MgmtPromptMainDesc,
+          }
+        );
+      }
+    } else if (PreviousAction === RecentShiftAction.BreakEnd && ActiveShift?.hasBreaks()) {
+      const EndedBreak = ActiveShift.events.breaks.findLast((v) => v[0] && v[1])!;
+      const BreaksTakenLine =
+        ActiveShift.events.breaks.length > 1
+          ? `**Breaks Taken:** ${ActiveShift.events.breaks.length}\n`
+          : "";
+
+      PromptEmbed.setColor(Embeds.Colors.ShiftOn);
+      PromptEmbed.setFooter({ text: `Shift Type: ${ShiftType}` });
+      PromptEmbed.setTitle(PreviousAction);
+      PromptEmbed.setFields({
+        inline: true,
+        name: "Current Shift",
+        value:
+          `>>> **Status:** (${Emojis.Online}) On Duty\n` +
+          `**Shift Started:** ${FormatTime(ActiveShift.start_timestamp, "R")}\n` +
+          BreaksTakenLine +
+          `**Ended Break Time:** ${EndedBreak[1] ? HumanizeDuration(EndedBreak[1] - EndedBreak[0]) : "N/A"}\n` +
+          `**Total Break Time:** ${ActiveShift.on_break_time}`,
+      });
+    } else if (PreviousAction === RecentShiftAction.BreakStart && ActiveShift?.hasBreakActive()) {
+      const StartedBreak = ActiveShift.events.breaks.findLast((v) => !v[1])!;
+      PromptEmbed.setColor(Embeds.Colors.ShiftBreak);
+      PromptEmbed.setFooter({ text: `Shift Type: ${ShiftType}` });
+      PromptEmbed.setTitle(PreviousAction);
+      PromptEmbed.setFields({
+        inline: true,
+        name: "Current Shift",
+        value: Dedent(`
+          >>> **Status:** (${Emojis.Idle}) On Break
+          **Shift Started:** ${FormatTime(ActiveShift.start_timestamp, "R")}
+          **Break Started:** ${FormatTime(Math.round(StartedBreak[0] / 1000), "R")}
+          **On-Duty Time:** ${ActiveShift.on_duty_time}
+          ${ActiveShift.events.breaks.length > 1 ? `**Total Break Time:** ${ActiveShift.on_break_time}` : ""}
+        `),
+      });
+    } else if (ActiveShift) {
+      PromptEmbed.setColor(Embeds.Colors.ShiftOn);
+      if (!PromptEmbed.data.fields?.find((Field) => Field.name === "Current Shift")) {
+        if (ActiveShift.durations.on_break > 500) {
+          PromptEmbed.addFields({
+            name: "Current Shift",
+            value: Dedent(`
+              >>> **Status:** (${Emojis.Online}) On Duty
+              **Shift Started:** ${FormatTime(ActiveShift.start_timestamp, "R")}
+              **Break Count:** ${inlineCode(ActiveShift.events.breaks.length.toString())}
+              **Total Break Time:** ${HumanizeDuration(ActiveShift.durations.on_break)}
+            `),
+          });
+        } else {
+          PromptEmbed.addFields({
+            name: "Current Shift",
+            value: Dedent(`
+              >>> **Status:** (${Emojis.Online}) On Duty
+              **Shift Started:** ${FormatTime(ActiveShift.start_timestamp, "R")}
+            `),
+          });
+        }
+      }
+    }
+  } else {
+    PromptEmbed.setFields({
+      inline: true,
+      name: "Statistics Summary",
+      value: MgmtPromptMainDesc,
+    });
+  }
+
+  if (Interaction.deferred || Interaction.replied) {
+    return Interaction.editReply({
+      message: PromptMsgId,
+      embeds: [PromptEmbed],
+      components: [ManagementComponents],
+    });
+  }
+
+  return Interaction.update({
+    embeds: [PromptEmbed],
+    components: [ManagementComponents],
+  });
+}
+
+/**
+ * Disables the interactive components (buttons) of a shift management prompt.
+ * This function updates the buttons to a disabled state and edits or updates the interaction reply accordingly.
+ * @param Interaction - The button interaction object.
+ * @param TargetShiftType - (Optional) The specific shift type to target when updating the buttons.
+ * @param SafeDisable - (Optional) If true, the function will not throw an error if the prompt cannot be updated. Defaults to true.
+ * @returns A promise that resolves when the interaction is updated or edited.
+ */
+async function DisablePromptComponents(
+  Interaction: ButtonInteraction<"cached">,
+  TargetShiftType?: string,
+  SafeDisable: boolean = true
+) {
+  const DisabledMgmtComponents = GetShiftManagementButtons(
+    Interaction,
+    TargetShiftType
+  ).updateButtons({ start: false, end: false, break: false });
+
+  try {
+    if (Interaction.deferred || Interaction.replied) {
+      await Interaction.editReply({
+        message: Interaction.message.id,
+        components: [DisabledMgmtComponents],
+      });
+    } else {
+      await Interaction.update({
+        components: [DisabledMgmtComponents],
+      });
+    }
+  } catch (Err) {
+    if (SafeDisable) return null;
+    else throw Err;
+  }
+}
+
+/**
+ * Extracts the shift type from the embed of the shift management prompt message.
+ * @param Interaction - The button interaction to process.
+ * @param ThrowIfNotFound - Whether to throw an error if the shift type is not found in the embed. Defaults to true.
+ * @returns
+ */
+function ExtractShiftTypeFromPrompt<TiNF extends boolean | undefined = true>(
+  Interaction: ButtonInteraction<"cached">,
+  ThrowIfNotFound?: TiNF
+): TiNF extends true ? string : string | null {
+  if (typeof ThrowIfNotFound !== "boolean") {
+    ThrowIfNotFound = true as TiNF;
+  }
+
+  const ShiftTypeFromCustomId = Interaction.customId.split(":")[2]?.trim();
+  if (ShiftTypeFromCustomId && IsValidShiftTypeName(ShiftTypeFromCustomId)) {
+    return ShiftTypeFromCustomId.toLowerCase() === "default" ? "Default" : ShiftTypeFromCustomId;
+  }
+
+  const Embed = Interaction.message.embeds[0];
+  if (!Embed) {
+    if (!ThrowIfNotFound) return null as any;
+    throw new AppError({ template: "DSMEmbedNotFound", showable: true });
+  }
+
+  const ShiftTypeTitle = Embed.title
+    ?.match(/(?:Shift|Duty)\s+?Manage(?:ment)?: `?([\w\s]+)`?/i)?.[1]
+    ?.trim();
+
+  if (ShiftTypeTitle) return ShiftTypeTitle;
+  const ShiftTypeFooter = Embed.footer?.text
+    .match(/(?:Shift|Duty)\s+?Type: `?([\w\s]+)`?/i)?.[1]
+    ?.trim();
+
+  if (ShiftTypeFooter) return ShiftTypeFooter;
+  if (!ThrowIfNotFound) return null as any;
+  throw new AppError({ template: "DSMContinueNoShiftTypeFound", showable: true });
+}

--- a/Source/Resources/AppMessages.ts
+++ b/Source/Resources/AppMessages.ts
@@ -795,6 +795,38 @@ export const ErrorMessages = {
     Description:
       "Extension requests are only available for leave of absence, not reduced activity.",
   },
+
+  /** Duty Shift Management - Embed Not Found  */
+  DSMEmbedNotFound: {
+    Title: "Missing Management Embed",
+    Description:
+      "This shift management prompt is either damaged or missing the management embed. Kindly re-execute the command again.",
+  },
+
+  /** Duty Shift Management - Continuation */
+  DSMContinueNoShiftTypeFound: {
+    Title: "Shift Type Unavailable",
+    Description:
+      "The shift type you have initially specified does not exist anymore and cannot be used. Kindly initiate another management process with a different shift type.",
+  },
+
+  DSMContinueExpired: {
+    Title: "Session Expired",
+    Description:
+      "This shift management session has timed out. Please restart the process by executing the command again.",
+  },
+
+  DSMInconsistentShiftActionShiftEnded: {
+    Title: "Inconsistent Shift Action",
+    Description:
+      "The shift you are trying to take action on has already ended, voided, or deleted and no further modifications can be made.",
+  },
+
+  DSMStateChangedExternally: {
+    Title: "Shift State Changed",
+    Description:
+      "The shift state has been modified elsewhere since this prompt was displayed. The prompt has been updated to reflect the current state.",
+  },
 };
 
 export const InfoMessages = {

--- a/Source/Resources/RegularExpressions.ts
+++ b/Source/Resources/RegularExpressions.ts
@@ -42,6 +42,7 @@ export const IncidentReportNumberLineRegex =
   /\bInc(?:ident|\.)\s(?:Num|Number|#)\*{0,3}:?\*{0,3}\s(?:`)?(?:INC-)?(\d{1,2}-\d{5,6})(?:`)?\b/i;
 
 export const UserActivityNoticeMgmtCustomIdRegex = /^(?:loa|ra)-(?:ext-)?(?:app|den|inf)[\w-]*:/;
+export const DutyManagementBtnCustomIdRegex = /^dm-(?:start|end|break):\d{15,22}:[\w\-. ]{3,20}/;
 
 export const LEORegex = /(?:Officer|Peace Officer|\bPolice\b|\bLEO\b|\bPO\b)s?/;
 export const AddStatutesRegexes = {

--- a/Source/Utilities/Other/GetFilledCitation.ts
+++ b/Source/Utilities/Other/GetFilledCitation.ts
@@ -22,7 +22,6 @@ const TWCTemplateImgBuffer = await FileSystem.readFile(
 const FineTemplate = await loadImage(TFCTemplateImgBuffer);
 const WarnTemplate = await loadImage(TWCTemplateImgBuffer);
 
-// eslint-disable-next-line sonarjs/cognitive-complexity
 export async function GetFilledCitation<AsURL extends boolean | undefined = undefined>(
   CitData: Omit<GuildCitations.AnyCitationData, "img_url">,
   ReturnAsURL?: AsURL

--- a/Source/Utilities/Strings/Redactor.ts
+++ b/Source/Utilities/Strings/Redactor.ts
@@ -242,7 +242,6 @@ export function RedactTextByOptions(Input: string, Options: RedactTextFromOption
  * @param Options - The options for filtering the user input.
  * @returns The filtered user input string.
  */
-// eslint-disable-next-line sonarjs/cognitive-complexity
 export async function FilterUserInput(Input: string, Options: FilterUserInputOptions = {}) {
   if (/^\s*$/.test(Input)) return Input;
   if (typeof Options.utif_setting_enabled !== "boolean") {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,13 +72,13 @@ export default [
       "no-useless-call": "error",
       "no-extra-parens": ["off", "functions"],
 
-      "sonarjs/cognitive-complexity": ["warn", 35],
+      "sonarjs/cognitive-complexity": ["warn", 45],
       "sonarjs/pseudo-random": "off",
       "sonarjs/todo-tag": "warn",
       "sonarjs/slow-regex": "off",
       "sonarjs/no-duplicate-string": "warn",
       "sonarjs/no-nested-conditional": "off",
-      "sonarjs/regex-complexity": ["warn", { threshold: 28 }],
+      "sonarjs/regex-complexity": ["warn", { threshold: 30 }],
 
       "no-irregular-whitespace": [
         "error",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,8 @@
 import { FlatCompat } from "@eslint/eslintrc";
 import { fileURLToPath } from "node:url";
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import stylisticJs from "@stylistic/eslint-plugin-js";
+
 import tsParser from "@typescript-eslint/parser";
 import sonarjs from "eslint-plugin-sonarjs";
 import globals from "globals";
@@ -34,6 +36,7 @@ export default [
   {
     plugins: {
       "@typescript-eslint": typescriptEslint,
+      "@stylistic/js": stylisticJs,
     },
   },
 
@@ -107,12 +110,12 @@ export default [
         },
       ],
 
-      indent: [
+      "@stylistic/js/indent": [
         "error",
         2,
         {
           SwitchCase: 1,
-          ignoredNodes: ["ConditionalExpression"],
+          ignoredNodes: ["ConditionalExpression *"],
         },
       ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.23.0",
         "@faker-js/faker": "^9.6.0",
+        "@stylistic/eslint-plugin-js": "^4.2.0",
         "@types/convert-units": "^2.3.9",
         "@types/express": "^5.0.0",
         "@types/humanize-duration": "^3.27.4",
@@ -2375,6 +2376,36 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-4.2.0.tgz",
+      "integrity": "sha512-MiJr6wvyzMYl/wElmj8Jns8zH7Q1w8XoVtm+WM6yDaTrfxryMyb8n0CMxt82fo42RoLIfxAEtM6tmQVxqhk0/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@tsconfig/node10": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.23.0",
     "@faker-js/faker": "^9.6.0",
+    "@stylistic/eslint-plugin-js": "^4.2.0",
     "@types/convert-units": "^2.3.9",
     "@types/express": "^5.0.0",
     "@types/humanize-duration": "^3.27.4",


### PR DESCRIPTION
Refactors the shift management system to use persistent button interactions, enabling staff to manage shifts (start, break, end) from a single prompt. Improves UX by allowing 24-hour validity for interactions without needing to re-run commands.

Key changes:
- Adds a handler for shift management interactions and related error messages.
- Introduces validation for duty management button custom IDs.
- Consolidates role (de)assignment into a single API call to prevent rate-limiting.
- Adjusts ESLint configuration for code style enforcement and increased complexity thresholds.
- Removes unnecessary logic and improves error handling for invalid shift actions.
